### PR TITLE
Add support for parsing and displaying Windows Terminal state.json

### DIFF
--- a/WTLayoutManager/Controls/TabLayoutControl.xaml
+++ b/WTLayoutManager/Controls/TabLayoutControl.xaml
@@ -1,0 +1,8 @@
+﻿<UserControl x:Class="WTLayoutManager.Controls.TabLayoutControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:WTLayoutManager.ViewModels"
+             x:Name="Root">
+    <!-- We'll have a Grid named MainGrid that will be built dynamically -->
+    <Grid x:Name="MainGrid" Background="Transparent"/>
+</UserControl>

--- a/WTLayoutManager/Controls/TabLayoutControl.xaml
+++ b/WTLayoutManager/Controls/TabLayoutControl.xaml
@@ -2,7 +2,9 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:WTLayoutManager.ViewModels"
+             Background="{DynamicResource MaterialDesignPaper}"
              x:Name="Root">
     <!-- We'll have a Grid named MainGrid that will be built dynamically -->
-    <Grid x:Name="MainGrid" Background="Transparent"/>
+    <Grid x:Name="MainGrid" 
+          Background="{DynamicResource MaterialDesignPaper}"/>
 </UserControl>

--- a/WTLayoutManager/Controls/TabLayoutControl.xaml.cs
+++ b/WTLayoutManager/Controls/TabLayoutControl.xaml.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using WTLayoutManager.ViewModels;
+
+namespace WTLayoutManager.Controls
+{
+    public partial class TabLayoutControl : UserControl
+    {
+        public static readonly DependencyProperty TabStateProperty =
+            DependencyProperty.Register(nameof(TabState), typeof(TabStateViewModel), typeof(TabLayoutControl),
+                new PropertyMetadata(null, OnTabStateChanged));
+
+        public TabStateViewModel TabState
+        {
+            get { return (TabStateViewModel)GetValue(TabStateProperty); }
+            set { SetValue(TabStateProperty, value); }
+        }
+
+        private static void OnTabStateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is TabLayoutControl control)
+            {
+                control.BuildGrid();
+            }
+        }
+
+        public TabLayoutControl()
+        {
+            InitializeComponent();
+        }
+
+        private void BuildGrid()
+        {
+            MainGrid.Children.Clear();
+            MainGrid.RowDefinitions.Clear();
+            MainGrid.ColumnDefinitions.Clear();
+
+            if (TabState == null)
+                return;
+
+            // Create the Grid definitions using the view model's grid size.
+            for (int i = 0; i < TabState.GridRows; i++)
+            {
+                MainGrid.RowDefinitions.Add(new RowDefinition());
+            }
+            for (int j = 0; j < TabState.GridColumns; j++)
+            {
+                MainGrid.ColumnDefinitions.Add(new ColumnDefinition());
+            }
+
+            // Add each pane into the grid.
+            foreach (var pane in TabState.Panes)
+            {
+                // Create a visual for the pane
+                var border = new Border
+                {
+                    BorderBrush = Brushes.Gray,
+                    BorderThickness = new Thickness(0.5),
+                    Margin = new Thickness(1)
+                };
+
+                var stack = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(2) };
+                var img = new Image
+                {
+                    Width = 16,
+                    Height = 16,
+                    Margin = new Thickness(0, 0, 4, 0)
+                };
+
+                try
+                {
+                    img.Source = new BitmapImage(new Uri(pane.Icon, UriKind.RelativeOrAbsolute));
+                }
+                catch
+                {
+                    // Fallback in case of a bad URI
+                    img.Source = null;
+                }
+
+                var txt = new TextBlock
+                {
+                    Text = pane.ProfileName,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Foreground = Brushes.White,
+                    Background = Brushes.Black,
+                    FontSize = 10
+                };
+
+                stack.Children.Add(img);
+                stack.Children.Add(txt);
+                border.Child = stack;
+
+                // Place in the grid using the view model values.
+                Grid.SetRow(border, pane.GridRow);
+                Grid.SetColumn(border, pane.GridColumn);
+                Grid.SetRowSpan(border, pane.GridRowSpan);
+                Grid.SetColumnSpan(border, pane.GridColumnSpan);
+
+                MainGrid.Children.Add(border);
+            }
+        }
+    }
+}

--- a/WTLayoutManager/Controls/TabLayoutControl.xaml.cs
+++ b/WTLayoutManager/Controls/TabLayoutControl.xaml.cs
@@ -57,8 +57,8 @@ namespace WTLayoutManager.Controls
                 // Create a visual for the pane
                 var border = new Border
                 {
-                    BorderBrush = Brushes.Gray,
-                    BorderThickness = new Thickness(0.5),
+                    BorderBrush = Brushes.DarkGray,
+                    BorderThickness = new Thickness(1.5),
                     Margin = new Thickness(1)
                 };
 
@@ -85,7 +85,7 @@ namespace WTLayoutManager.Controls
                     Text = pane.ProfileName,
                     VerticalAlignment = VerticalAlignment.Center,
                     Foreground = Brushes.White,
-                    Background = Brushes.Black,
+                    //Background = Brushes.Black,
                     FontSize = 10
                 };
 

--- a/WTLayoutManager/Converters/StateJsonVisibilityConverter.cs
+++ b/WTLayoutManager/Converters/StateJsonVisibilityConverter.cs
@@ -1,0 +1,18 @@
+﻿using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace WTLayoutManager.Converters
+{
+    public class StateJsonVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            => (value as string)?.Equals("state.json", StringComparison.OrdinalIgnoreCase) == true || 
+            (value as string)?.Equals("elevated-state.json", StringComparison.OrdinalIgnoreCase) == true
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => throw new NotImplementedException();
+    }
+}

--- a/WTLayoutManager/MainWindow.xaml
+++ b/WTLayoutManager/MainWindow.xaml
@@ -45,13 +45,24 @@
         </DataTemplate>
         <!-- Template for a single tab's layout -->
         <DataTemplate x:Key="TabRowTemplate" DataType="{x:Type vm:TabStateViewModel}">
-            <Border BorderBrush="DarkGray" BorderThickness="1" Padding="2" Margin="2">
-                <controls:TabLayoutControl TabState="{Binding}" />
-            </Border>
+            <StackPanel Background="#FF323232" Margin="5">
+                <Border Background="#FF323232" BorderBrush="DarkGray" BorderThickness="1.5" Padding="2" Margin="2">
+                    <StackPanel>
+                        <!-- Display the tab title -->
+                        <TextBlock Text="{Binding TabTitle}" 
+                                   FontWeight="Bold" 
+                                   Margin="0,0,0,4" 
+                                   Foreground="{DynamicResource MaterialDesignBody}" />
+                        <Border Background="#FF323232" BorderBrush="DarkGray" BorderThickness="1.5" Padding="2" Margin="2">
+                            <controls:TabLayoutControl TabState="{Binding}" />
+                        </Border>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
         </DataTemplate>
         <!-- Overall tooltip template: a vertical stack of tab rows -->
         <DataTemplate x:Key="StateTooltipTemplate" DataType="{x:Type vm:StateJsonTooltipViewModel}">
-            <StackPanel>
+            <StackPanel Background="#FF464646">
                 <ItemsControl ItemsSource="{Binding TabStates}" ItemTemplate="{StaticResource TabRowTemplate}" />
             </StackPanel>
         </DataTemplate>

--- a/WTLayoutManager/MainWindow.xaml
+++ b/WTLayoutManager/MainWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:converters="clr-namespace:WTLayoutManager.Converters"
         xmlns:services="clr-namespace:WTLayoutManager.Services"
         xmlns:vm="clr-namespace:WTLayoutManager.ViewModels"
+        xmlns:controls="clr-namespace:WTLayoutManager.Controls"
         Style="{StaticResource MaterialDesignWindow}"
         Title="WT Layout Manager" 
         Height="600" Width="800">
@@ -13,6 +14,7 @@
     <Window.Resources>
         <converters:IntToVisibilityConverter x:Key="IntToVisibilityConverter"/>
         <converters:SettingsJsonVisibilityConverter x:Key="SettingsJsonVisibilityConverter"/>
+        <converters:StateJsonVisibilityConverter x:Key="StateJsonVisibilityConverter"/>
         <Style x:Key="MyCustomDataGridRowStyle"
                TargetType="DataGridRow"
                BasedOn="{StaticResource {x:Type DataGridRow}}">
@@ -40,6 +42,18 @@
                     </ItemsControl>
                 </StackPanel>
             </Border>
+        </DataTemplate>
+        <!-- Template for a single tab's layout -->
+        <DataTemplate x:Key="TabRowTemplate" DataType="{x:Type vm:TabStateViewModel}">
+            <Border BorderBrush="DarkGray" BorderThickness="1" Padding="2" Margin="2">
+                <controls:TabLayoutControl TabState="{Binding}" />
+            </Border>
+        </DataTemplate>
+        <!-- Overall tooltip template: a vertical stack of tab rows -->
+        <DataTemplate x:Key="StateTooltipTemplate" DataType="{x:Type vm:StateJsonTooltipViewModel}">
+            <StackPanel>
+                <ItemsControl ItemsSource="{Binding TabStates}" ItemTemplate="{StaticResource TabRowTemplate}" />
+            </StackPanel>
         </DataTemplate>
     </Window.Resources>
     
@@ -245,11 +259,20 @@
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Orientation="Horizontal">
-                                            <TextBlock Text="{Binding FileName}" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding FileName}" VerticalAlignment="Center"
+                                                       Visibility="{Binding FileName, Converter={StaticResource SettingsJsonVisibilityConverter}}">
                                                 <TextBlock.ToolTip>
                                                     <ToolTip Content="{Binding Profiles}" 
                                                              ContentTemplate="{StaticResource ProfilesTooltipTemplate}"
                                                              Visibility="{Binding FileName, Converter={StaticResource SettingsJsonVisibilityConverter}}"/>
+                                                </TextBlock.ToolTip>
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding FileName}" VerticalAlignment="Center"
+                                                       Visibility="{Binding FileName, Converter={StaticResource StateJsonVisibilityConverter}}">
+                                                <TextBlock.ToolTip>
+                                                    <ToolTip Content="{Binding TabStates}" 
+                                                             ContentTemplate="{StaticResource StateTooltipTemplate}"
+                                                             Visibility="{Binding FileName, Converter={StaticResource StateJsonVisibilityConverter}}"/>
                                                 </TextBlock.ToolTip>
                                             </TextBlock>
                                         </StackPanel>

--- a/WTLayoutManager/Models/FileModel.cs
+++ b/WTLayoutManager/Models/FileModel.cs
@@ -8,5 +8,6 @@ namespace WTLayoutManager.Models
         public DateTime LastModified { get; set; }
         public long Size { get; set; }
         public SettingsJsonTooltipViewModel Profiles { get; set; }
+        public StateJsonTooltipViewModel TabStates { get; set; }
     }
 }

--- a/WTLayoutManager/Models/StateJson.cs
+++ b/WTLayoutManager/Models/StateJson.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace WTLayoutManager.Models
+{
+    public class StateJson
+    {
+        [JsonPropertyName("persistedWindowLayouts")]
+        public List<PersistedWindowLayout> PersistedWindowLayouts { get; set; }
+    }
+
+    public class PersistedWindowLayout
+    {
+        [JsonPropertyName("tabLayout")]
+        public List<TabLayoutAction> TabLayout { get; set; }
+    }
+
+    public class TabLayoutAction
+    {
+        [JsonPropertyName("action")]
+        public string Action { get; set; }
+
+        [JsonPropertyName("commandline")]
+        public string Commandline { get; set; }
+
+        [JsonPropertyName("profile")]
+        public string Profile { get; set; }
+
+        [JsonPropertyName("sessionId")]
+        public string SessionId { get; set; }
+
+        [JsonPropertyName("startingDirectory")]
+        public string StartingDirectory { get; set; }
+
+        [JsonPropertyName("suppressApplicationTitle")]
+        public bool SuppressApplicationTitle { get; set; }
+
+        [JsonPropertyName("tabTitle")]
+        public string TabTitle { get; set; }
+
+        [JsonPropertyName("size")]
+        public double? Size { get; set; }
+
+        [JsonPropertyName("split")]
+        public string Split { get; set; }
+
+        // For focusPane actions.
+        [JsonPropertyName("id")]
+        public int? Id { get; set; }
+
+        // For switchToTab actions.
+        [JsonPropertyName("index")]
+        public int? Index { get; set; }
+    }
+}

--- a/WTLayoutManager/Models/StateJson.cs
+++ b/WTLayoutManager/Models/StateJson.cs
@@ -51,5 +51,9 @@ namespace WTLayoutManager.Models
         // For switchToTab actions.
         [JsonPropertyName("index")]
         public int? Index { get; set; }
+
+        // For moveFocus actions.
+        [JsonPropertyName("direction")]
+        public string Direction { get; set; }
     }
 }

--- a/WTLayoutManager/Services/SettingsJsonParser.cs
+++ b/WTLayoutManager/Services/SettingsJsonParser.cs
@@ -19,6 +19,9 @@ namespace WTLayoutManager.Services
     {
         public static IEnumerable<ProfileInfo> GetProfileInfos(string filePath)
         {
+            if (Path.GetFileName(filePath) != "settings.json")
+                yield break;
+
             if (!File.Exists(filePath))
                 yield break;
 

--- a/WTLayoutManager/Services/StateJsonParser.cs
+++ b/WTLayoutManager/Services/StateJsonParser.cs
@@ -152,6 +152,27 @@ namespace WTLayoutManager.Services
                         }
                     }
                 }
+                else if (action.Action.Equals("moveFocus", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (currentTab != null && currentTab.Panes.Count > 0 && currentFocusedPane != null)
+                    {
+                        int currentIndex = currentTab.Panes.IndexOf(currentFocusedPane);
+                        if (!string.IsNullOrWhiteSpace(action.Direction))
+                        {
+                            string dir = action.Direction.ToLowerInvariant();
+                            if (dir == "previousinorder")
+                            {
+                                int newIndex = (currentIndex - 1 + currentTab.Panes.Count) % currentTab.Panes.Count;
+                                currentFocusedPane = currentTab.Panes[newIndex];
+                            }
+                            else if (dir == "nextinorder")
+                            {
+                                int newIndex = (currentIndex + 1) % currentTab.Panes.Count;
+                                currentFocusedPane = currentTab.Panes[newIndex];
+                            }
+                        }
+                    }
+                }
                 else if (action.Action.Equals("switchToTab", StringComparison.OrdinalIgnoreCase))
                 {
                     // switchToTab uses property "index".

--- a/WTLayoutManager/Services/StateJsonParser.cs
+++ b/WTLayoutManager/Services/StateJsonParser.cs
@@ -52,7 +52,11 @@ namespace WTLayoutManager.Services
                 if (action.Action.Equals("newTab", StringComparison.OrdinalIgnoreCase))
                 {
                     // Create a new tab.
-                    currentTab = new TabStateViewModel();
+                    currentTab = new TabStateViewModel
+                    {
+                        // Set the title from the action.
+                        TabTitle = action.TabTitle
+                    };
                     // First pane occupies full area.
                     var pane = new PaneViewModel
                     {

--- a/WTLayoutManager/Services/StateJsonParser.cs
+++ b/WTLayoutManager/Services/StateJsonParser.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using WTLayoutManager.Models;
+using WTLayoutManager.ViewModels;
+
+namespace WTLayoutManager.Services
+{
+    public static class StateJsonParser
+    {
+        public static StateJsonTooltipViewModel ParseState(string filePath)
+        {
+            var fileName = Path.GetFileName(filePath);
+            if (!fileName.EndsWith("state.json"))
+                return null;
+
+            if (!File.Exists(filePath))
+                return null;
+
+            string json = File.ReadAllText(filePath);
+            var options = new JsonSerializerOptions
+            {
+                ReadCommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true
+            };
+
+            StateJson state;
+            try
+            {
+                state = JsonSerializer.Deserialize<StateJson>(json, options);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+            if (state?.PersistedWindowLayouts == null || state.PersistedWindowLayouts.Count == 0)
+                return null;
+
+            var layout = state.PersistedWindowLayouts[0];
+            if (layout.TabLayout == null || layout.TabLayout.Count == 0)
+                return null;
+
+            var tooltipVm = new StateJsonTooltipViewModel();
+            var tabs = new List<TabStateViewModel>();
+            TabStateViewModel currentTab = null;
+            // Maintain the current focused pane's coordinates within the current tab.
+            int currentFocusRow = 0, currentFocusColumn = 0;
+
+            foreach (var action in layout.TabLayout)
+            {
+                if (action.Action.Equals("newTab", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Create a new tab; the first pane is placed at (0,0).
+                    currentTab = new TabStateViewModel();
+                    var pane = new PaneViewModel
+                    {
+                        ProfileName = action.Profile,
+                        Icon = GetIconForProfile(action.Profile),
+                        GridRow = 0,
+                        GridColumn = 0,
+                        GridRowSpan = 1,
+                        GridColumnSpan = 1
+                    };
+                    currentTab.Panes.Add(pane);
+                    currentFocusRow = 0;
+                    currentFocusColumn = 0;
+                    tabs.Add(currentTab);
+                }
+                else if (action.Action.Equals("splitPane", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (currentTab != null)
+                    {
+                        int newRow = currentFocusRow;
+                        int newCol = currentFocusColumn;
+                        // Determine the new pane's position based on the split direction.
+                        string splitDir = action.Split?.ToLowerInvariant();
+                        if (splitDir == "up")
+                        {
+                            newRow = currentFocusRow - 1;
+                        }
+                        else if (splitDir == "down")
+                        {
+                            newRow = currentFocusRow + 1;
+                        }
+                        else if (splitDir == "left")
+                        {
+                            newCol = currentFocusColumn - 1;
+                        }
+                        else if (splitDir == "right")
+                        {
+                            newCol = currentFocusColumn + 1;
+                        }
+                        // Create the new pane.
+                        var pane = new PaneViewModel
+                        {
+                            ProfileName = action.Profile,
+                            Icon = GetIconForProfile(action.Profile),
+                            GridRow = newRow,
+                            GridColumn = newCol,
+                            GridRowSpan = 1,
+                            GridColumnSpan = 1,
+                            SplitDirection = splitDir
+                        };
+                        currentTab.Panes.Add(pane);
+                        // Update focus to the new pane.
+                        currentFocusRow = newRow;
+                        currentFocusColumn = newCol;
+                    }
+                }
+                else if (action.Action.Equals("focusPane", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Use the 'id' property to update focus.
+                    if (action.Id.HasValue && currentTab != null)
+                    {
+                        int target = action.Id.Value;
+                        if (target >= 0 && target < currentTab.Panes.Count)
+                        {
+                            currentFocusRow = currentTab.Panes[target].GridRow;
+                            currentFocusColumn = currentTab.Panes[target].GridColumn;
+                        }
+                    }
+                }
+                else if (action.Action.Equals("switchToTab", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Use the 'index' property to switch tabs.
+                    if (action.Index.HasValue)
+                    {
+                        int tabIndex = action.Index.Value;
+                        if (tabIndex >= 0 && tabIndex < tabs.Count)
+                        {
+                            currentTab = tabs[tabIndex];
+                            // Reset focus to the first pane of that tab.
+                            if (currentTab.Panes.Count > 0)
+                            {
+                                currentFocusRow = currentTab.Panes[0].GridRow;
+                                currentFocusColumn = currentTab.Panes[0].GridColumn;
+                            }
+                        }
+                    }
+                }
+                // You can extend handling for additional actions as needed.
+            }
+
+            // Adjust coordinates so that the smallest row/column is 0 for each tab.
+            foreach (var tab in tabs)
+            {
+                if (tab.Panes.Count == 0) continue;
+                int minRow = int.MaxValue, minCol = int.MaxValue;
+                int maxRow = int.MinValue, maxCol = int.MinValue;
+                foreach (var pane in tab.Panes)
+                {
+                    if (pane.GridRow < minRow) minRow = pane.GridRow;
+                    if (pane.GridColumn < minCol) minCol = pane.GridColumn;
+                    if (pane.GridRow > maxRow) maxRow = pane.GridRow;
+                    if (pane.GridColumn > maxCol) maxCol = pane.GridColumn;
+                }
+                foreach (var pane in tab.Panes)
+                {
+                    pane.GridRow -= minRow;
+                    pane.GridColumn -= minCol;
+                }
+                tab.GridRows = maxRow - minRow + 1;
+                tab.GridColumns = maxCol - minCol + 1;
+            }
+
+            // Add all tabs to the tooltip view model.
+            foreach (var tab in tabs)
+            {
+                tooltipVm.TabStates.Add(tab);
+            }
+            return tooltipVm;
+        }
+
+        /// <summary>
+        /// A simple mapping from profile name to an icon path.
+        /// </summary>
+        private static string GetIconForProfile(string profileName)
+        {
+            // In a real app, you might look up profile details from settings.json.
+            return "pack://application:,,,/WTLayoutManager;component/Assets/cmd.png";
+        }
+    }
+}

--- a/WTLayoutManager/Services/StateJsonParser.cs
+++ b/WTLayoutManager/Services/StateJsonParser.cs
@@ -9,7 +9,7 @@ namespace WTLayoutManager.Services
 {
     public static class StateJsonParser
     {
-        public static StateJsonTooltipViewModel ParseState(string filePath)
+        public static StateJsonTooltipViewModel ParseState(string filePath, Dictionary<string, string> profileIcons)
         {
             var fileName = Path.GetFileName(filePath);
             if (!fileName.EndsWith("state.json"))
@@ -61,7 +61,7 @@ namespace WTLayoutManager.Services
                     var pane = new PaneViewModel
                     {
                         ProfileName = action.Profile,
-                        Icon = GetIconForProfile(action.Profile),
+                        Icon = GetIconForProfile(action.Profile, profileIcons),
                         X = 0,
                         Y = 0,
                         Width = 1,
@@ -87,7 +87,7 @@ namespace WTLayoutManager.Services
                         PaneViewModel newPane = new PaneViewModel
                         {
                             ProfileName = action.Profile,
-                            Icon = GetIconForProfile(action.Profile),
+                            Icon = GetIconForProfile(action.Profile, profileIcons),
                             SplitDirection = splitDir
                         };
 
@@ -261,9 +261,13 @@ namespace WTLayoutManager.Services
         /// <summary>
         /// A simple mapping from profile name to an icon path.
         /// </summary>
-        private static string GetIconForProfile(string profileName)
+        private static string GetIconForProfile(string profileName, Dictionary<string, string> profileIcons)
         {
             // In a real app, you might look up profile details from settings.json.
+            if (profileIcons.ContainsKey(profileName))
+            {
+                return profileIcons[profileName];
+            }
             return "pack://application:,,,/WTLayoutManager;component/Assets/cmd.png";
         }
     }

--- a/WTLayoutManager/ViewModels/MainViewModel.cs
+++ b/WTLayoutManager/ViewModels/MainViewModel.cs
@@ -175,6 +175,14 @@ namespace WTLayoutManager.ViewModels
             // and should refresh automatically.
         }
 
+        public static Dictionary<string, string> MapProfilesToIcons(ObservableCollection<ProfileInfo> profiles)
+        {
+            // Assumes each profile's ProfileName is unique.
+            return profiles
+                .GroupBy(p => p.ProfileName)
+                .ToDictionary(g => g.Key, g => g.First().IconPath);
+        }
+
         private FolderModel CreateFolderModel(string folderPath, string folderName, bool isDefault)
         {
             var model = new FolderModel
@@ -186,9 +194,10 @@ namespace WTLayoutManager.ViewModels
             };
 
             // We only care about these 3 possible files:
-            var interestingFiles = new[] { "state.json", "elevated-state.json", "settings.json" };
+            var interestingFiles = new[] { "settings.json", "state.json", "elevated-state.json" };
 
             // Populate the list of FileModel if files exist
+            var mapProfilesToIcons = new Dictionary<string, string>();
             foreach (string fileName in interestingFiles)
             {
                 string fullPath = Path.Combine(folderPath, fileName);
@@ -196,7 +205,9 @@ namespace WTLayoutManager.ViewModels
                 {
                     var fi = new FileInfo(fullPath);
                     var tooltipProfiles = new ObservableCollection<ProfileInfo>(SettingsJsonParser.GetProfileInfos(fullPath));
-                    var stateTooltipVm = StateJsonParser.ParseState(fullPath);
+                    if (mapProfilesToIcons.Count == 0)
+                        mapProfilesToIcons = MapProfilesToIcons(tooltipProfiles);
+                    var stateTooltipVm = StateJsonParser.ParseState(fullPath, mapProfilesToIcons);
                     var tooltipVm = new SettingsJsonTooltipViewModel
                     {
                         Profiles = tooltipProfiles

--- a/WTLayoutManager/ViewModels/MainViewModel.cs
+++ b/WTLayoutManager/ViewModels/MainViewModel.cs
@@ -196,6 +196,7 @@ namespace WTLayoutManager.ViewModels
                 {
                     var fi = new FileInfo(fullPath);
                     var tooltipProfiles = new ObservableCollection<ProfileInfo>(SettingsJsonParser.GetProfileInfos(fullPath));
+                    var stateTooltipVm = StateJsonParser.ParseState(fullPath);
                     var tooltipVm = new SettingsJsonTooltipViewModel
                     {
                         Profiles = tooltipProfiles
@@ -205,7 +206,8 @@ namespace WTLayoutManager.ViewModels
                         FileName = fi.Name,
                         LastModified = fi.LastWriteTime,
                         Size = fi.Length,
-                        Profiles = tooltipVm
+                        Profiles = tooltipVm,
+                        TabStates = stateTooltipVm
                     });
                     if (model.LastRun == null && fileName == "state.json")
                     {

--- a/WTLayoutManager/ViewModels/PaneViewModel.cs
+++ b/WTLayoutManager/ViewModels/PaneViewModel.cs
@@ -1,0 +1,15 @@
+﻿namespace WTLayoutManager.ViewModels
+{
+    public class PaneViewModel
+    {
+        public string ProfileName { get; set; }
+        public string Icon { get; set; }
+        // Grid positioning information.
+        public int GridRow { get; set; } = 0;
+        public int GridColumn { get; set; } = 0;
+        public int GridRowSpan { get; set; } = 1;
+        public int GridColumnSpan { get; set; } = 1;
+        // Store the split direction if applicable.
+        public string SplitDirection { get; set; }
+    }
+}

--- a/WTLayoutManager/ViewModels/PaneViewModel.cs
+++ b/WTLayoutManager/ViewModels/PaneViewModel.cs
@@ -4,12 +4,19 @@
     {
         public string ProfileName { get; set; }
         public string Icon { get; set; }
-        // Grid positioning information.
+        // Geometry in normalized coordinates
+        public double X { get; set; }      // Left position
+        public double Y { get; set; }      // Top position
+        public double Width { get; set; }
+        public double Height { get; set; }
+
+        // Grid placement (computed later)
         public int GridRow { get; set; } = 0;
         public int GridColumn { get; set; } = 0;
         public int GridRowSpan { get; set; } = 1;
         public int GridColumnSpan { get; set; } = 1;
-        // Store the split direction if applicable.
+
+        // Store the split direction (for reference if needed)
         public string SplitDirection { get; set; }
     }
 }

--- a/WTLayoutManager/ViewModels/StateJsonTooltipViewModel.cs
+++ b/WTLayoutManager/ViewModels/StateJsonTooltipViewModel.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.ObjectModel;
+
+namespace WTLayoutManager.ViewModels
+{
+    public class StateJsonTooltipViewModel
+    {
+        public ObservableCollection<TabStateViewModel> TabStates { get; set; } = new ObservableCollection<TabStateViewModel>();
+    }
+}

--- a/WTLayoutManager/ViewModels/TabStateViewModel.cs
+++ b/WTLayoutManager/ViewModels/TabStateViewModel.cs
@@ -4,6 +4,7 @@ namespace WTLayoutManager.ViewModels
 {
     public class TabStateViewModel
     {
+        public string? TabTitle { get; set; }
         public int GridRows { get; set; } = 1;
         public int GridColumns { get; set; } = 1;
         public ObservableCollection<PaneViewModel> Panes { get; set; } = new ObservableCollection<PaneViewModel>();

--- a/WTLayoutManager/ViewModels/TabStateViewModel.cs
+++ b/WTLayoutManager/ViewModels/TabStateViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.ObjectModel;
+
+namespace WTLayoutManager.ViewModels
+{
+    public class TabStateViewModel
+    {
+        public int GridRows { get; set; } = 1;
+        public int GridColumns { get; set; } = 1;
+        public ObservableCollection<PaneViewModel> Panes { get; set; } = new ObservableCollection<PaneViewModel>();
+    }
+}

--- a/WTLayoutManager/WTLayoutManager.csproj
+++ b/WTLayoutManager/WTLayoutManager.csproj
@@ -31,10 +31,13 @@
     <None Remove="Assets\{61c54bbd-c2c6-5271-96e7-009a87ff44bf}.png" />
     <None Remove="Assets\{9acb9455-ca41-5af7-950f-6bca1bc9722f}.png" />
     <None Remove="Assets\{b453ae62-4e3d-5e58-b989-0a998ec441b8}.png" />
+    <None Remove="Resources\WindowsTerminalLayoutManager.PNG" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Resources\WindowsTerminalLayoutManager.ico" />
+    <Resource Include="Resources\WindowsTerminalLayoutManager.ico">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Resource>
   </ItemGroup>
 
   <ItemGroup>
@@ -105,6 +108,11 @@
     <Resource Include="Assets\{b453ae62-4e3d-5e58-b989-0a998ec441b8}.png">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Resource>
+    <Resource Include="Resources\WindowsTerminalLayoutManager.PNG">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Resource>
   </ItemGroup>
 
   <ItemGroup>
@@ -131,10 +139,6 @@
     <None Update="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-    <None Update="Resources\WindowsTerminalLayoutManager.PNG">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
State ToolTip

## Summary by Sourcery

Adds support for parsing and displaying the contents of Windows Terminal state.json files, including tab layouts and pane arrangements.

New Features:
- Adds support for parsing and displaying Windows Terminal state.json files.
- Displays tab layouts and pane arrangements from state.json files in the UI.