### PR TITLE
Improve WT process handling and fix DLL replacement

### DIFF
--- a/ElevatedLauncher/ElevatedLauncher.cpp
+++ b/ElevatedLauncher/ElevatedLauncher.cpp
@@ -118,6 +118,11 @@ int wmain(int argc, wchar_t *argv[])
     success = ResumeThread(pi.pi.hThread);
 
     HANDLE hReal = WinApiHelpers::GetWindowsTerminalHandle(pi.pi.dwProcessId);
+    if (hReal == nullptr)
+    {
+        std::wcerr << L"GetWindowsTerminalHandle failed." << std::endl;
+        return -1;
+    }
 
     HandlePtr piHandle(hReal, &::CloseHandle);
 

--- a/ElevatedLauncher/ElevatedLauncher.cpp
+++ b/ElevatedLauncher/ElevatedLauncher.cpp
@@ -117,14 +117,12 @@ int wmain(int argc, wchar_t *argv[])
 
     success = ResumeThread(pi.pi.hThread);
 
-    HANDLE hReal = WinApiHelpers::GetWindowsTerminalHandle(pi.pi.dwProcessId);
-    if (hReal == nullptr)
+    HandlePtr piHandle = WinApiHelpers::GetWindowsTerminalHandle(pi.pi.dwProcessId);
+    if (piHandle.get() == nullptr)
     {
         std::wcerr << L"GetWindowsTerminalHandle failed." << std::endl;
         return -1;
     }
-
-    HandlePtr piHandle(hReal, &::CloseHandle);
 
     // Wait for the target process to exit.
     WaitForSingleObject(piHandle.get(), INFINITE);

--- a/ProcessLauncher/ProcessLauncherWrapper.cpp
+++ b/ProcessLauncher/ProcessLauncherWrapper.cpp
@@ -105,6 +105,10 @@ int ProcessLauncher::LaunchProcess(System::String^ applicationPath, System::Stri
     success = ResumeThread(pi.pi.hThread);
 
     HANDLE hReal = WinApiHelpers::GetWindowsTerminalHandle(pi.pi.dwProcessId);
+    if (hReal == nullptr)
+	{
+		throw gcnew System::Exception(gcnew System::String(WinApiHelpers::GetLastErrorMessage().c_str()));
+	}
 
     HandlePtr piHandle(hReal, &::CloseHandle);
 

--- a/ProcessLauncher/ProcessLauncherWrapper.cpp
+++ b/ProcessLauncher/ProcessLauncherWrapper.cpp
@@ -104,13 +104,11 @@ int ProcessLauncher::LaunchProcess(System::String^ applicationPath, System::Stri
     //success = DebugActiveProcess(pi.dwProcessId);
     success = ResumeThread(pi.pi.hThread);
 
-    HANDLE hReal = WinApiHelpers::GetWindowsTerminalHandle(pi.pi.dwProcessId);
-    if (hReal == nullptr)
+    HandlePtr piHandle = WinApiHelpers::GetWindowsTerminalHandle(pi.pi.dwProcessId);
+    if (piHandle.get() == nullptr)
 	{
 		throw gcnew System::Exception(gcnew System::String(WinApiHelpers::GetLastErrorMessage().c_str()));
 	}
-
-    HandlePtr piHandle(hReal, &::CloseHandle);
 
     // Wait for the process to exit.
     WaitForSingleObject(piHandle.get(), INFINITE);

--- a/ProcessLauncher/ProcessLauncherWrapper.cpp
+++ b/ProcessLauncher/ProcessLauncherWrapper.cpp
@@ -13,6 +13,7 @@
 #include <crtdbg.h>
 #include <sstream>
 #include <iomanip>
+#include <tlhelp32.h>
 #include <msclr/marshal_cppstd.h>
 #include <msclr/auto_handle.h>
 
@@ -47,7 +48,7 @@ int ProcessLauncher::LaunchProcess(System::String^ applicationPath, System::Stri
     // 1. ----- DUPLICATE COMMAND LINE --------------------------------------
     size_t cmdLen = wcslen(cmdRaw) + 1;
     std::unique_ptr<wchar_t[]> cmdLine(new wchar_t[cmdLen]);
-    if (FAILED(StringCchCopyW(cmdLine.get(), cmdLen, cmdRaw))) 
+    if (FAILED(StringCchCopyW(cmdLine.get(), cmdLen, cmdRaw)))
     {
         throw gcnew System::Exception(gcnew System::String(WinApiHelpers::GetLastErrorMessage().c_str()));
     }
@@ -59,7 +60,7 @@ int ProcessLauncher::LaunchProcess(System::String^ applicationPath, System::Stri
         array<System::String^>^ parts = envBlock->Split(L';');
         for each (System::String^ part in parts)
         {
-            if (System::String::IsNullOrWhiteSpace(part)) 
+            if (System::String::IsNullOrWhiteSpace(part))
                 continue;      // skip empty
 
             additional.emplace_back(ctx->marshal_as<const wchar_t*>(part));
@@ -68,14 +69,15 @@ int ProcessLauncher::LaunchProcess(System::String^ applicationPath, System::Stri
 
     // 3. ----- MERGE with parent environment ------------------------------
     std::unique_ptr<wchar_t[]> merged;
-    DWORD dwCreationFlags = 0;
+    DWORD dwCreationFlags = NORMAL_PRIORITY_CLASS | CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP | CREATE_SUSPENDED;
     if (!additional.empty())
     {
         merged.reset(WinApiHelpers::CreateMergedEnvironmentBlock(additional));
-        dwCreationFlags = CREATE_UNICODE_ENVIRONMENT;
+        dwCreationFlags |= CREATE_UNICODE_ENVIRONMENT;
     }
 
     STARTUPINFOEXW si{ sizeof(si) };
+    si.StartupInfo.wShowWindow = SW_SHOWDEFAULT;
     process_info_raii pi;
 
     std::wstring hookW(hookRaw);
@@ -85,7 +87,7 @@ int ProcessLauncher::LaunchProcess(System::String^ applicationPath, System::Stri
         cmdLine.get(),      // command line (inherit)
         nullptr, nullptr,   // security attrs
         FALSE,              // inherit handles
-        dwCreationFlags | CREATE_SUSPENDED,
+        dwCreationFlags,
         merged.get(),       // Custom environment block
         nullptr,            // cwd
         &si.StartupInfo,
@@ -102,14 +104,18 @@ int ProcessLauncher::LaunchProcess(System::String^ applicationPath, System::Stri
     //success = DebugActiveProcess(pi.dwProcessId);
     success = ResumeThread(pi.pi.hThread);
 
+    HANDLE hReal = WinApiHelpers::GetWindowsTerminalHandle(pi.pi.dwProcessId);
+
+    HandlePtr piHandle(hReal, &::CloseHandle);
+
     // Wait for the process to exit.
-    WaitForSingleObject(pi.pi.hProcess, INFINITE);
+    WaitForSingleObject(piHandle.get(), INFINITE);
 
     merged.reset();
     cmdLine.reset();
 
     DWORD exitCode = 0;
-    if (!GetExitCodeProcess(pi.pi.hProcess, &exitCode))
+    if (!GetExitCodeProcess(piHandle.get(), &exitCode))
     {
         throw gcnew System::Exception(gcnew System::String(WinApiHelpers::GetLastErrorMessage().c_str()));
     }

--- a/WTLayoutManager/ViewModels/FolderViewModel.cs
+++ b/WTLayoutManager/ViewModels/FolderViewModel.cs
@@ -63,7 +63,14 @@ namespace WTLayoutManager.ViewModels
                 try
                 {
                     File.Copy(_srcHookPath, tmp, overwrite: true);
-                    File.Replace(tmp, _dstHookPath, destinationBackupFileName: null, ignoreMetadataErrors: true);
+                    if (!File.Exists(_dstHookPath))
+                    {
+                        File.Move(tmp, _dstHookPath, overwrite: true);
+                    }
+                    else
+                    {
+                        File.Replace(tmp, _dstHookPath, destinationBackupFileName: null, ignoreMetadataErrors: true);
+                    }
                 }
                 finally
                 {
@@ -261,7 +268,7 @@ namespace WTLayoutManager.ViewModels
         private string BuildTerminalPath(TerminalInfo terminalInfo)
         {
             //return "C:\\Users\\dmitr\\src\\terminal\\bin\\x64\\Debug\\WindowsTerminal\\WindowsTerminal.exe";
-            var fileName = System.IO.Path.Combine(terminalInfo.InstalledLocationPath, "WindowsTerminal.exe");
+            var fileName = System.IO.Path.Combine(terminalInfo.InstalledLocationPath, "wt.exe");
             if (!File.Exists(fileName))
             {
                 fileName = System.IO.Path.Combine(terminalInfo.InstalledLocationPath, "wtd.exe");

--- a/WTLayoutManagerBundle/Package.appxmanifest
+++ b/WTLayoutManagerBundle/Package.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="6b79d320-09e1-4140-b2a7-7b0218794aa3"
     Publisher="CN=Dm17tryK"
-    Version="1.0.105.0" />
+    Version="1.0.106.0" />
 
   <Properties>
     <DisplayName>Installer</DisplayName>

--- a/WTLayoutManagerBundle/Package.appxmanifest
+++ b/WTLayoutManagerBundle/Package.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="6b79d320-09e1-4140-b2a7-7b0218794aa3"
     Publisher="CN=Dm17tryK"
-    Version="1.0.103.0" />
+    Version="1.0.104.0" />
 
   <Properties>
     <DisplayName>Installer</DisplayName>

--- a/WTLayoutManagerBundle/Package.appxmanifest
+++ b/WTLayoutManagerBundle/Package.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="6b79d320-09e1-4140-b2a7-7b0218794aa3"
     Publisher="CN=Dm17tryK"
-    Version="1.0.104.0" />
+    Version="1.0.105.0" />
 
   <Properties>
     <DisplayName>Installer</DisplayName>

--- a/WinApiHelpers/WinApiHelpers.cpp
+++ b/WinApiHelpers/WinApiHelpers.cpp
@@ -1,6 +1,7 @@
 ﻿#include "pch.h"
 #include "WinApiHelpers.h"
 #include <strsafe.h>
+#include <tlhelp32.h>
 #include <detours.h>
 
 using namespace WTLayoutManager::Services;
@@ -44,13 +45,13 @@ shellexecuteinfow_raii::operator SHELLEXECUTEINFOW* () noexcept
 
 // --------------------------------------------------------------------------
 
-process_info_raii::process_info_raii() 
-{ 
-    ZeroMemory(&pi, sizeof(pi)); 
+process_info_raii::process_info_raii()
+{
+    ZeroMemory(&pi, sizeof(pi));
 }
-process_info_raii::~process_info_raii() 
-{ 
-    reset(); 
+process_info_raii::~process_info_raii()
+{
+    reset();
 }
 
 process_info_raii::process_info_raii(process_info_raii&& other) noexcept
@@ -76,8 +77,8 @@ void process_info_raii::reset() noexcept
 }
 
 // implicit conversion when a PROCESS_INFORMATION* is required
-process_info_raii::operator PROCESS_INFORMATION* () noexcept 
-{ 
+process_info_raii::operator PROCESS_INFORMATION* () noexcept
+{
     return &pi;
 }
 
@@ -206,4 +207,33 @@ BOOL WinApiHelpers::DetourCreateProcessWithDllExWrap(
         lpDllName,
         reinterpret_cast<PDETOUR_CREATE_PROCESS_ROUTINEW>(pfCreateProcessW)
     );
+}
+
+void WinApiHelpers::Sleep(_In_ DWORD dwMilliseconds)
+{
+	::Sleep(dwMilliseconds);
+}
+
+HANDLE WinApiHelpers::GetWindowsTerminalHandle(DWORD wtPid)
+{
+    DWORD parentPid = wtPid;
+    HANDLE hReal = nullptr;
+    while (!hReal) {
+        HANDLE hSnap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        PROCESSENTRY32 pe{ sizeof(pe) };
+        for (BOOL ok = Process32First(hSnap, &pe); ok; ok = Process32Next(hSnap, &pe)) {
+            if (pe.th32ParentProcessID == parentPid
+                && _wcsicmp(pe.szExeFile, L"WindowsTerminal.exe") == 0)
+            {
+                // open with SYNCHRONIZE so we can wait on it:
+                DWORD rights = SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION;
+                hReal = OpenProcess(rights, FALSE, pe.th32ProcessID);
+                break;
+            }
+        }
+        CloseHandle(hSnap);
+        if (!hReal)
+            WinApiHelpers::Sleep(50);
+    }
+    return hReal;
 }

--- a/WinApiHelpers/WinApiHelpers.cpp
+++ b/WinApiHelpers/WinApiHelpers.cpp
@@ -218,8 +218,13 @@ HANDLE WinApiHelpers::GetWindowsTerminalHandle(DWORD wtPid)
 {
     DWORD parentPid = wtPid;
     HANDLE hReal = nullptr;
-    while (!hReal) {
+    for (int i = 0; i < 60 && !hReal; ++i) {
         HANDLE hSnap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+		if (hSnap == INVALID_HANDLE_VALUE)
+        {
+            WinApiHelpers::Sleep(50);
+			continue;
+        }
         PROCESSENTRY32 pe{ sizeof(pe) };
         for (BOOL ok = Process32First(hSnap, &pe); ok; ok = Process32Next(hSnap, &pe)) {
             if (pe.th32ParentProcessID == parentPid
@@ -233,7 +238,9 @@ HANDLE WinApiHelpers::GetWindowsTerminalHandle(DWORD wtPid)
         }
         CloseHandle(hSnap);
         if (!hReal)
+        {
             WinApiHelpers::Sleep(50);
+        }
     }
     return hReal;
 }

--- a/WinApiHelpers/WinApiHelpers.cpp
+++ b/WinApiHelpers/WinApiHelpers.cpp
@@ -214,7 +214,7 @@ void WinApiHelpers::Sleep(_In_ DWORD dwMilliseconds)
 	::Sleep(dwMilliseconds);
 }
 
-HANDLE WinApiHelpers::GetWindowsTerminalHandle(DWORD wtPid)
+HandlePtr WinApiHelpers::GetWindowsTerminalHandle(DWORD wtPid)
 {
     DWORD parentPid = wtPid;
     HANDLE hReal = nullptr;
@@ -242,5 +242,6 @@ HANDLE WinApiHelpers::GetWindowsTerminalHandle(DWORD wtPid)
             WinApiHelpers::Sleep(50);
         }
     }
-    return hReal;
+
+    return HandlePtr(hReal);
 }

--- a/WinApiHelpers/WinApiHelpers.h
+++ b/WinApiHelpers/WinApiHelpers.h
@@ -1,10 +1,11 @@
-#pragma once
+﻿#pragma once
 
 #include "new.h"
 #include <windows.h>
 #include <shellapi.h>
 #include <string>
 #include <vector>
+#include <memory>
 
 #ifdef WINAPIHELPERS_EXPORTS   // Define this in your pure C++ DLL project settings
 #define WINAPIHELPERS_API __declspec(dllexport)
@@ -14,6 +15,11 @@
 
 namespace WTLayoutManager {
 	namespace Services {
+
+        using HandlePtr = std::unique_ptr<
+            std::remove_pointer_t<HANDLE>,   // = void
+            decltype(&::CloseHandle)         // function‐pointer deleter type
+        >;
 
         struct shellexecuteinfow_raii
         {
@@ -96,6 +102,10 @@ namespace WTLayoutManager {
                 _In_opt_ void* pfCreateProcessW);
 
             WINAPIHELPERS_API static std::string WideToUtf8(const std::wstring& ws);
+
+            WINAPIHELPERS_API static void Sleep(_In_ DWORD dwMilliseconds);
+
+            WINAPIHELPERS_API static HANDLE GetWindowsTerminalHandle(DWORD wtPid);
 		};
 
 	}

--- a/WinApiHelpers/WinApiHelpers.h
+++ b/WinApiHelpers/WinApiHelpers.h
@@ -16,9 +16,15 @@
 namespace WTLayoutManager {
 	namespace Services {
 
+        struct HandleCloser {
+            void operator()(HANDLE h) const noexcept {
+                if (h) ::CloseHandle(h);
+            }
+        };
+
         using HandlePtr = std::unique_ptr<
             std::remove_pointer_t<HANDLE>,   // = void
-            decltype(&::CloseHandle)         // function‐pointer deleter type
+            HandleCloser        // function‐pointer deleter type
         >;
 
         struct shellexecuteinfow_raii
@@ -105,7 +111,7 @@ namespace WTLayoutManager {
 
             WINAPIHELPERS_API static void Sleep(_In_ DWORD dwMilliseconds);
 
-            WINAPIHELPERS_API static HANDLE GetWindowsTerminalHandle(DWORD wtPid);
+            WINAPIHELPERS_API static HandlePtr GetWindowsTerminalHandle(DWORD wtPid);
 		};
 
 	}

--- a/WinApiHelpers/WinApiHelpers.h
+++ b/WinApiHelpers/WinApiHelpers.h
@@ -18,7 +18,7 @@ namespace WTLayoutManager {
 
         struct HandleCloser {
             void operator()(HANDLE h) const noexcept {
-                if (h) ::CloseHandle(h);
+                if (h && h != INVALID_HANDLE_VALUE) ::CloseHandle(h);
             }
         };
 


### PR DESCRIPTION
## Summary by Sourcery

Improve Windows Terminal process launch and waiting logic by enumerating and waiting on the actual host process, standardize launcher flags and handle lifetimes, and fix DLL hook replacement and executable path resolution.

New Features:
- Add GetWindowsTerminalHandle to enumerate and retrieve the actual Windows Terminal host process handle.
- Introduce Sleep wrapper and HandlePtr RAII handle abstraction in WinApiHelpers.

Bug Fixes:
- Fix hook DLL replacement in FolderViewModel by moving the file when the destination is missing.

Enhancements:
- Standardize process creation flags and console behavior in ElevatedLauncher and ProcessLauncherWrapper.
- Refactor launchers to use process_info_raii, set default window show flags, and wait on the terminal host process handle.
- Update default Windows Terminal executable path to wt.exe with a wtd.exe fallback.